### PR TITLE
Add auto-fixing behavior to mirror the behavior of existing hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: ruff-conda
   name: ruff-conda
   description: "Run 'ruff' for extremely fast Python linting"
-  entry: ruff
+  entry: ruff --fix --exit-non-zero-on-fix
   language: conda
   require_serial: false
   types: [python]


### PR DESCRIPTION
As per the recommendation here: https://beta.ruff.rs/docs/usage/#pre-commit

It's not the default in the official hook so we might decide against this PR. Auto-fixing seems to be in line with all other pre-commit mirrors though.