### PR TITLE
Use ruff check <path> instead of deprecated ruff <path>

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: ruff-conda
   name: ruff-conda
   description: 'Run `ruff` for extremely fast Python linting'
-  entry: ruff --fix --exit-non-zero-on-fix
+  entry: ruff check --fix --exit-non-zero-on-fix --force-exclude
   language: conda
   types_or: [python, pyi]
   args: []


### PR DESCRIPTION
![image](https://github.com/Quantco/pre-commit-mirrors-ruff/assets/146940934/1ef1d51b-e5be-4f6a-ab39-9ead918acdca)
